### PR TITLE
Update Project for Android Studio 3.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In order to build the project:
 1. git clone git@github.com:fiveagency/Reedly.git
 2. Import the project into Android Studio by selecting settings.gradle file in the root of the project.
 
-**NOTE:** You should use at least Android Studio 3.0
+**NOTE:** You should use at least Android Studio 3.1
 
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,14 +1,10 @@
 apply plugin: 'com.android.application'
-apply plugin: 'me.tatarka.retrolambda'
 
 buildscript {
     repositories {
         jcenter()
         mavenCentral()
         maven { url 'https://maven.fabric.io/public' }
-    }
-    dependencies {
-        classpath 'me.tatarka:gradle-retrolambda:' + project.ext.retrolambdaVersion
     }
 }
 
@@ -58,10 +54,6 @@ task version {
     }
 }
 
-retrolambda {
-    jvmArgs '-noverify'
-}
-
 android {
     compileSdkVersion project.ext.compileSdkVersion
     buildToolsVersion project.ext.buildToolsVersion
@@ -97,28 +89,28 @@ dependencies {
     implementation project(':data')
     implementation project(':device')
 
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:appcompat-v7:" + project.ext.supportLibVersion
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:appcompat-v7:" + project.ext.supportLibVersion
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:' + project.ext.mockitoVersion
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:' + project.ext.mockitoVersion
 
     annotationProcessor 'com.google.dagger:dagger-compiler:2.14.1'
-    compile 'com.google.dagger:dagger:2.14.1'
+    implementation 'com.google.dagger:dagger:2.14.1'
 
-    compile 'com.annimon:stream:' + project.ext.streamsVersion
-    compile 'io.reactivex:rxjava:' + project.ext.rxJavaVersion
-    compile 'io.reactivex:rxandroid:' + project.ext.rxAndroidVersion
+    implementation 'com.annimon:stream:' + project.ext.streamsVersion
+    implementation 'io.reactivex:rxjava:' + project.ext.rxJavaVersion
+    implementation 'io.reactivex:rxandroid:' + project.ext.rxAndroidVersion
 
-    compile 'com.jakewharton:butterknife:8.8.1'
+    implementation 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
 
-    compile 'com.google.code.gson:gson:2.8.2'
-    compile "com.android.support:design:" + project.ext.supportLibVersion
-    compile "com.android.support:recyclerview-v7:" + project.ext.supportLibVersion
-    compile "com.android.support:cardview-v7:" + project.ext.supportLibVersion
+    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation "com.android.support:design:" + project.ext.supportLibVersion
+    implementation "com.android.support:recyclerview-v7:" + project.ext.supportLibVersion
+    implementation "com.android.support:cardview-v7:" + project.ext.supportLibVersion
 
-    compile 'com.facebook.stetho:stetho:1.5.0'
+    implementation 'com.facebook.stetho:stetho:1.5.0'
 
-    compile 'com.github.bumptech.glide:glide:4.5.0'
+    implementation 'com.github.bumptech.glide:glide:4.6.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -21,16 +21,15 @@ allprojects {
     }
 
     project.ext {
-        buildToolsVersion = "27.0.2"
+        buildToolsVersion = "27.0.3"
         minSdkVersion = 21
         targetSdkVersion = 27
         compileSdkVersion = 27
 
-        supportLibVersion = "27.0.2"
+        supportLibVersion = "27.1.0"
         rxJavaVersion = "1.3.0"
         rxAndroidVersion = "1.2.1"
         streamsVersion = "1.1.7"
-        retrolambdaVersion = "3.2.5"
         mockitoVersion = "2.8.9"
     }
 }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,13 +1,8 @@
 apply plugin: 'com.android.library'
-apply plugin: 'me.tatarka.retrolambda'
 
 buildscript {
     repositories {
         mavenCentral()
-    }
-
-    dependencies {
-        classpath 'me.tatarka:gradle-retrolambda:' + project.ext.retrolambdaVersion
     }
 }
 
@@ -43,23 +38,23 @@ def dbflow_version = "4.0.0-beta5"
 
 dependencies {
 
-    compile project(':domain')
+    implementation project(':domain')
 
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:appcompat-v7:" + project.ext.supportLibVersion
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:appcompat-v7:" + project.ext.supportLibVersion
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:' + project.ext.mockitoVersion
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:' + project.ext.mockitoVersion
 
-    compile 'io.reactivex:rxjava:' + project.ext.rxJavaVersion
-    compile 'io.reactivex:rxandroid:' + project.ext.rxAndroidVersion
-    compile 'com.annimon:stream:' + project.ext.streamsVersion
+    implementation 'io.reactivex:rxjava:' + project.ext.rxJavaVersion
+    implementation 'io.reactivex:rxandroid:' + project.ext.rxAndroidVersion
+    implementation 'com.annimon:stream:' + project.ext.streamsVersion
 
-    compile 'javax.inject:javax.inject:1'
+    implementation 'javax.inject:javax.inject:1'
 
     annotationProcessor "com.github.Raizlabs.DBFlow:dbflow-processor:${dbflow_version}"
-    compile "com.github.Raizlabs.DBFlow:dbflow-core:${dbflow_version}"
-    compile "com.github.Raizlabs.DBFlow:dbflow:${dbflow_version}"
+    api "com.github.Raizlabs.DBFlow:dbflow-core:${dbflow_version}"
+    api "com.github.Raizlabs.DBFlow:dbflow:${dbflow_version}"
 
-    compile 'com.einmalfel:earl:1.2.0'
+    implementation 'com.einmalfel:earl:1.2.0'
 }

--- a/device/build.gradle
+++ b/device/build.gradle
@@ -23,15 +23,15 @@ android {
 
 dependencies {
 
-    compile project(':domain')
+    implementation project(':domain')
 
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile "com.android.support:appcompat-v7:" + project.ext.supportLibVersion
+    implementation "com.android.support:appcompat-v7:" + project.ext.supportLibVersion
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:' + project.ext.mockitoVersion
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:' + project.ext.mockitoVersion
 }

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -3,29 +3,14 @@ buildscript {
     repositories {
         mavenCentral()
     }
-
-    dependencies {
-        classpath 'me.tatarka:gradle-retrolambda:3.2.5'
-    }
 }
 
-// Required because retrolambda is on maven central
-repositories {
-    mavenCentral()
-}
 
-apply plugin: 'me.tatarka.retrolambda'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'io.reactivex:rxjava:' + project.ext.rxJavaVersion
-    compile 'com.annimon:stream:' + project.ext.streamsVersion
-    compile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-inline:' + project.ext.mockitoVersion
-}
-
-retrolambda {
-    jdk System.getenv("JAVA8_HOME")
-    defaultMethods true
-    incremental false
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'io.reactivex:rxjava:' + project.ext.rxJavaVersion
+    implementation 'com.annimon:stream:' + project.ext.streamsVersion
+    implementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-inline:' + project.ext.mockitoVersion
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 27 11:39:04 CET 2018
+#Tue Mar 27 17:50:59 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Updated:
buildToolsVersion 27.0.2 -> 27.0.3
supportLibVersion 27.0.2 -> 27.1.0
Android Plugin for Gradle 3.0.1 ->  3.1.0
Gradle Wrapper 4.3 -> 4.4
glide 4.5.0 -> 4.6.1

Replaced:
depreciated "compile" with "implementation" and "api" in gradle files

Removed:
retrolambda (unneeded)